### PR TITLE
early exit in and

### DIFF
--- a/src/composite/object.spec.ts
+++ b/src/composite/object.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable unicorn/no-null */
 
+import { refine } from "../refine";
 import { InferType } from "../schema";
 import { number } from "../simple/number";
 import { string } from "../simple/string";
@@ -254,6 +255,24 @@ describe("merge", () => {
       "nested",
       "more",
     ]);
+  });
+
+  it("interops with refine", () => {
+    const s = merge(
+      refine(schema, ({ id, name }, { validIf }) => {
+        return { name: validIf(name.length > id, "asdf") };
+      }),
+      object({ more: string() })
+    );
+    expect(
+      translate(
+        s.validate({
+          id: 4,
+          name: ["some", "string"],
+          nested: { user: "3" },
+        })
+      )
+    ).toEqual({ name: "asdf", more: "value is required" });
   });
 });
 

--- a/src/logic/and.spec.ts
+++ b/src/logic/and.spec.ts
@@ -60,6 +60,7 @@ it("validates", () => {
     translate(schema.validate({ id: "", name: ["some", "string"], nested: {} }))
   ).toEqual({
     id: "value was of type string expected number",
+    nested: { user: "value is required" },
   });
   expect(
     translate(schema.validate({ id: 12, name: ["some", "string"], nested: {} }))


### PR DESCRIPTION
this worked once but after the rewrite of parts of the code it stopped working. Now the default behavior is to run the merged validations. This enables for much more fine-grained merging of object schemata.